### PR TITLE
Rewrite to use JavaIsoVisitor with .kt files

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,31 @@
+name: "pull_request"
+
+on: pull_request
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: check
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'reports'
+          path: '**/build/reports/**'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
 
     implementation("org.openrewrite:rewrite-kotlin:0.2.0")
 
-
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite.recipe:rewrite-testing-frameworks")
     testImplementation("org.junit.jupiter:junit-jupiter-api:latest.release")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     compileOnly("org.projectlombok:lombok:latest.release")
     implementation("org.openrewrite:rewrite-java")
 
-    implementation("org.openrewrite:rewrite-kotlin:0.2.0-SNAPSHOT")
+    implementation("org.openrewrite:rewrite-kotlin:0.2.1")
 
     testRuntimeOnly("io.arrow-kt:arrow-core:1.1.6-alpha.28")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
+    maven("https://oss.sonatype.org/content/repositories/snapshots/")
 }
 
 tasks.named<JavaCompile>("compileJava") {
@@ -16,13 +17,16 @@ tasks.named<JavaCompile>("compileJava") {
 
 tasks.test {
     useJUnitPlatform()
-
 }
 
 rewrite {
     activeRecipe(
         "arrow.SayHelloRecipe"
     )
+}
+
+configurations.all {
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
 }
 
 dependencies {
@@ -33,7 +37,9 @@ dependencies {
     compileOnly("org.projectlombok:lombok:latest.release")
     implementation("org.openrewrite:rewrite-java")
 
-    implementation("org.openrewrite:rewrite-kotlin:0.2.0")
+    implementation("org.openrewrite:rewrite-kotlin:0.2.0-SNAPSHOT")
+
+    testRuntimeOnly("io.arrow-kt:arrow-core:1.1.6-alpha.28")
 
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite.recipe:rewrite-testing-frameworks")

--- a/src/main/java/arrow/SayHelloRecipe.java
+++ b/src/main/java/arrow/SayHelloRecipe.java
@@ -45,7 +45,7 @@ public class SayHelloRecipe extends Recipe {
 
     public class SayHelloVisitor extends JavaIsoVisitor<ExecutionContext> {
         private final JavaTemplate helloTemplate =
-                JavaTemplate.builder(this::getCursor, "public fun hello(): String { return \"Hello from #{}!\" }")
+                JavaTemplate.builder(this::getCursor, "public String hello() { return \"Hello from #{}!\"; }")
                         .build();
 
         @Override

--- a/src/main/java/arrow/SayHelloRecipe.java
+++ b/src/main/java/arrow/SayHelloRecipe.java
@@ -14,7 +14,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.kotlin.KotlinIsoVisitor;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class SayHelloRecipe extends Recipe {
     @Option(displayName = "Fully qualified class name",
             description = "A fully qualified class name indicating which class to add a `hello()` method to.",
@@ -44,7 +44,7 @@ public class SayHelloRecipe extends Recipe {
 
     public class SayHelloVisitor extends KotlinIsoVisitor<ExecutionContext> {
         private final JavaTemplate helloTemplate =
-                JavaTemplate.builder(this::getCursor, "public fun hello(): String { return \"Hello from #{}!\"; }")
+                JavaTemplate.builder(this::getCursor, "public fun hello(): String { return \"Hello from #{}!\" }")
                         .build();
 
         @Override
@@ -66,8 +66,6 @@ public class SayHelloRecipe extends Recipe {
             if (helloMethodExists) {
                 return classDecl;
             }
-
-            final J.Block block = classDecl.getBody();
 
             // Interpolate the fullyQualifiedClassName into the template and use the resulting LST to update the class body
             classDecl = classDecl.withBody(

--- a/src/main/java/arrow/SayHelloRecipe.java
+++ b/src/main/java/arrow/SayHelloRecipe.java
@@ -9,6 +9,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.kotlin.KotlinIsoVisitor;
@@ -42,7 +43,7 @@ public class SayHelloRecipe extends Recipe {
         return new SayHelloVisitor();
     }
 
-    public class SayHelloVisitor extends KotlinIsoVisitor<ExecutionContext> {
+    public class SayHelloVisitor extends JavaIsoVisitor<ExecutionContext> {
         private final JavaTemplate helloTemplate =
                 JavaTemplate.builder(this::getCursor, "public fun hello(): String { return \"Hello from #{}!\" }")
                         .build();
@@ -69,13 +70,11 @@ public class SayHelloRecipe extends Recipe {
 
             // Interpolate the fullyQualifiedClassName into the template and use the resulting LST to update the class body
             classDecl = classDecl.withBody(
-                    classDecl
-                            .getBody()
-                            .withTemplate(
-                                    helloTemplate,
-                                    classDecl.getBody().getCoordinates().lastStatement(),
-                                    fullyQualifiedClassName
-                            ));
+                    classDecl.getBody().withTemplate(
+                            helloTemplate,
+                            classDecl.getBody().getCoordinates().lastStatement(),
+                            fullyQualifiedClassName
+                    ));
 
             return classDecl;
         }

--- a/src/test/java/arrow/SayHelloRecipeTest.java
+++ b/src/test/java/arrow/SayHelloRecipeTest.java
@@ -46,9 +46,7 @@ class SayHelloRecipeTest implements RewriteTest {
               package com.yourorg
 
               class FooBar {
-                  public fun hello(): String {
-                      return "Hello from com.yourorg.FooBar!"
-                  }
+                  public fun hello(): String { return "" }
               }
               """
           )

--- a/src/test/java/arrow/SayHelloRecipeTest.java
+++ b/src/test/java/arrow/SayHelloRecipeTest.java
@@ -5,6 +5,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class SayHelloRecipeTest implements RewriteTest {
     @Override
@@ -15,20 +16,20 @@ class SayHelloRecipeTest implements RewriteTest {
     @Test
     void addsHelloToFooBar() {
         rewriteRun(
-          //language=java
-          java(
+          //language=kotlin
+          kotlin(
             """
-              package com.yourorg;
+              package com.yourorg
 
               class FooBar {
               }
               """,
             """
-              package com.yourorg;
+              package com.yourorg
 
               class FooBar {
-                  public String hello() {
-                      return "Hello from com.yourorg.FooBar!";
+                  public fun hello(): String {
+                      return "Hello from com.yourorg.FooBar!"
                   }
               }
               """
@@ -39,13 +40,15 @@ class SayHelloRecipeTest implements RewriteTest {
     @Test
     void doesNotChangeExistingHello() {
         rewriteRun(
-          //language=java
-          java(
+          //language=kotlin
+          kotlin(
             """
-              package com.yourorg;
+              package com.yourorg
 
               class FooBar {
-                  public String hello() { return ""; }
+                  public fun hello(): String {
+                      return "Hello from com.yourorg.FooBar!"
+                  }
               }
               """
           )
@@ -55,10 +58,10 @@ class SayHelloRecipeTest implements RewriteTest {
     @Test
     void doesNotChangeOtherClasses() {
         rewriteRun(
-          //language=java
-          java(
+          //language=kotlin
+          kotlin(
             """
-              package com.yourorg;
+              package com.yourorg
 
               class Bash {
               }


### PR DESCRIPTION
Attempted to rewrite the `JavaIsoVisitor` example of [Writing a Java Refactoring Recipe](https://docs.openrewrite.org/authoring-recipes/writing-a-java-refactoring-recipe) to Kotlin, and ran into the following error.

I tried to keep the changes in this PR to a minimal, but some additional information:
 - Same issue occurs when using `KotlinIsoVisitor`
 - Same issue occurs if using `JavaTemplate.builder(this::getCursor, "public fun hello(): String { return \"Hello from #{}!\" }")`
 - As the stacktrace below indicates the line triggering this exception in the user code is `J.withTemplate` on [line 74](https://github.com/nomisRev/rewrite-arrow/blob/0f4730113428263cf722cfb5afc8c89867f74ecc/src/main/java/arrow/SayHelloRecipe.java#L74) in `SayHelloRecipe.java`.

Failing with following output:

```text
java.lang.AssertionError: Failed to parse sources or run recipe
	at org.openrewrite.test.RewriteTest.lambda$defaultExecutionContext$11(RewriteTest.java:511)
	at org.openrewrite.RecipeScheduler.lambda$scheduleVisit$4(RecipeScheduler.java:274)
	at org.openrewrite.RecipeScheduler.lambda$mapAsync$0(RecipeScheduler.java:56)
	at org.openrewrite.scheduling.DirectScheduler.schedule(DirectScheduler.java:35)
	at org.openrewrite.RecipeScheduler.mapAsync(RecipeScheduler.java:57)
	at org.openrewrite.RecipeScheduler.scheduleVisit(RecipeScheduler.java:236)
	at org.openrewrite.test.RecipeSchedulerCheckingExpectedCycles.scheduleVisit(RecipeSchedulerCheckingExpectedCycles.java:50)
	at org.openrewrite.RecipeScheduler.scheduleRun(RecipeScheduler.java:101)
	at org.openrewrite.Recipe.run(Recipe.java:330)
	at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:319)
	at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:128)
	at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:123)
	at arrow.SayHelloRecipeTest.addsHelloToFooBar(SayHelloRecipeTest.java:18)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:217)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:96)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy1/jdk.proxy1.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: org.openrewrite.internal.RecipeRunException: Exception while visiting project file 'null (in FooBar)', caused by: java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.J$Block.getMarkers()" because the return value of "org.openrewrite.java.tree.J$ClassDeclaration.getBody()" is null, at org.openrewrite.kotlin.internal.KotlinPrinter$KotlinJavaPrinter.visitClassDeclaration(KotlinPrinter.java:303)
	at app//org.openrewrite.TreeVisitor.visit(TreeVisitor.java:324)
	at app//org.openrewrite.kotlin.internal.KotlinPrinter$KotlinJavaPrinter.visit(KotlinPrinter.java:198)
	at app//org.openrewrite.kotlin.internal.KotlinPrinter.visit(KotlinPrinter.java:45)
	at app//org.openrewrite.kotlin.internal.KotlinPrinter.visit(KotlinPrinter.java:38)
	at app//org.openrewrite.TreeVisitor.visit(TreeVisitor.java:172)
	at app//org.openrewrite.Tree.print(Tree.java:93)
	at app//org.openrewrite.Tree.print(Tree.java:89)
	at app//org.openrewrite.Tree.printTrimmed(Tree.java:108)
	at app//org.openrewrite.java.internal.template.BlockStatementTemplateGenerator.classDeclaration(BlockStatementTemplateGenerator.java:538)
	at app//org.openrewrite.java.internal.template.BlockStatementTemplateGenerator.template(BlockStatementTemplateGenerator.java:189)
	at app//org.openrewrite.java.internal.template.BlockStatementTemplateGenerator.lambda$template$0(BlockStatementTemplateGenerator.java:84)
	at app//io.micrometer.core.instrument.composite.CompositeTimer.record(CompositeTimer.java:65)
	at app//org.openrewrite.java.internal.template.BlockStatementTemplateGenerator.template(BlockStatementTemplateGenerator.java:71)
	at app//org.openrewrite.java.internal.template.JavaTemplateParser.parseBlockStatements(JavaTemplateParser.java:158)
	at app//org.openrewrite.java.internal.template.JavaTemplateJavaExtension$1.visitBlock(JavaTemplateJavaExtension.java:80)
	at app//org.openrewrite.java.internal.template.JavaTemplateJavaExtension$1.visitBlock(JavaTemplateJavaExtension.java:59)
	at app//org.openrewrite.java.tree.J$Block.acceptJava(J.java:761)
	at app//org.openrewrite.java.tree.J.accept(J.java:64)
	at app//org.openrewrite.TreeVisitor.visit(TreeVisitor.java:276)
	at app//org.openrewrite.TreeVisitor.visit(TreeVisitor.java:172)
	at app//org.openrewrite.java.JavaTemplate.withTemplate(JavaTemplate.java:107)
	at app//org.openrewrite.java.JavaTemplate.withTemplate(JavaTemplate.java:39)
	at app//org.openrewrite.java.tree.J.withTemplate(J.java:91)
	at app//arrow.SayHelloRecipe$SayHelloVisitor.visitClassDeclaration(SayHelloRecipe.java:76)
	at app//arrow.SayHelloRecipe$SayHelloVisitor.visitClassDeclaration(SayHelloRecipe.java:45)
	at app//org.openrewrite.java.tree.J$ClassDeclaration.acceptJava(J.java:1211)
	at app//org.openrewrite.java.tree.J.accept(J.java:64)
	at app//org.openrewrite.TreeVisitor.visit(TreeVisitor.java:276)
	at app//org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:356)
	at app//org.openrewrite.kotlin.KotlinVisitor.lambda$visitCompilationUnit$2(KotlinVisitor.java:54)
	at app//org.openrewrite.internal.ListUtils.lambda$map$0(ListUtils.java:145)
	at app//org.openrewrite.internal.ListUtils.map(ListUtils.java:126)
	at app//org.openrewrite.internal.ListUtils.map(ListUtils.java:145)
	at app//org.openrewrite.kotlin.KotlinVisitor.visitCompilationUnit(KotlinVisitor.java:54)
	at app//org.openrewrite.kotlin.KotlinVisitor.visitJavaSourceFile(KotlinVisitor.java:42)
	at app//org.openrewrite.kotlin.tree.K$CompilationUnit.acceptKotlin(K.java:177)
	at app//org.openrewrite.kotlin.tree.K.accept(K.java:48)
	at app//org.openrewrite.TreeVisitor.visit(TreeVisitor.java:276)
	at app//org.openrewrite.RecipeScheduler.lambda$scheduleVisit$4(RecipeScheduler.java:270)
	... 94 more
Caused by: java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.J$Block.getMarkers()" because the return value of "org.openrewrite.java.tree.J$ClassDeclaration.getBody()" is null
	at org.openrewrite.kotlin.internal.KotlinPrinter$KotlinJavaPrinter.visitClassDeclaration(KotlinPrinter.java:303)
	at org.openrewrite.kotlin.internal.KotlinPrinter$KotlinJavaPrinter.visitClassDeclaration(KotlinPrinter.java:191)
	at org.openrewrite.java.tree.J$ClassDeclaration.acceptJava(J.java:1211)
	at org.openrewrite.java.tree.J.accept(J.java:64)
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:276)
	... 132 more
```